### PR TITLE
Add terms and privacy policy from HelloVote

### DIFF
--- a/assets/css/_setup.scss
+++ b/assets/css/_setup.scss
@@ -38,7 +38,7 @@ $base-font-weight: normal;
 $bold-font-weight: bold;
 $base-line-height: 1.6;
 
-$font-size-1: 36px;
+$font-size-1: 42px;
 $font-size-2: 30px;
 $font-size-3: 24px;
 // $font-size-4: $base-font-size;
@@ -47,6 +47,7 @@ $font-size-6: 12px;
 
 $m-font-size-1: 24px;
 $m-font-size-2: 20px;
+$m-font-size-3: $base-font-size;
 $m-font-size-6: 10px;
 
 // Layout

--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -39,6 +39,14 @@ h2 {
     font-size: $font-size-2;
   }
 }
+h3 {
+  font-size: $m-font-size-3;
+  text-transform: none;
+
+  @include respond-to(lrg) {
+    font-size: $font-size-3;
+  }
+}
 
 // Typography > Text
 p {

--- a/assets/css/components/_article.scss
+++ b/assets/css/components/_article.scss
@@ -1,0 +1,22 @@
+// Article
+
+.article h1 {
+  margin-top: $gutter*6;
+  margin-bottom: $gutter*2;
+  text-align: center;
+}
+.article h2 {
+  margin-top: $gutter*4;
+  margin-bottom: $gutter*2;
+  text-align: center;
+}
+.article h3,
+.article p,
+.article ul,
+.article ol,
+.article iframe {
+  margin-bottom: $gutter;
+}
+.article img {
+  margin: $gutter*2 auto;
+}

--- a/assets/css/components/_buttons.scss
+++ b/assets/css/components/_buttons.scss
@@ -17,6 +17,7 @@
   border-radius: $default-border-radius;
   color: $white;
   cursor: pointer;
+  font-family: $heading-stack;
   font-size: $base-font-size;
   font-weight: $bold-font-weight;
   outline: none;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,3 +14,4 @@
 @import "components/_buttons";
 @import "components/_page-footer";
 @import "components/_chat";
+@import "components/_article";

--- a/components/Chat.vue
+++ b/components/Chat.vue
@@ -27,7 +27,7 @@
             <a href="https://www.fightforthefuture.org/" target="_blank">
               Fight for the Future</a>
             &amp; its Education Fund will contact you.
-            <a href="#TODO">Privacy Policy</a>
+            <nuxt-link to="/privacy">Privacy Policy</nuxt-link>
           </small>
         </p>
       </div> <!-- form container -->

--- a/components/Logo.vue
+++ b/components/Logo.vue
@@ -1,0 +1,4 @@
+<template>
+  <img src="~assets/images/logo.png" class="img-logo grid-center"
+       alt="Vote for Net Neutrality logo" />
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,9 +4,7 @@
       <div class="wrapper">
         <div class="row">
           <div class="sml-c12 lrg-c8 grid-center">
-            <img src="~assets/images/logo.png" class="img-logo grid-center"
-                 alt="Vote for Net Neutrality logo" />
-
+            <Logo/>
             <Chat/>
           </div> <!-- .c -->
         </div> <!-- .row -->
@@ -237,11 +235,13 @@
 <script>
 import config from '~/config'
 import { createMetaTags, smoothScrollToElement } from '~/assets/js/helpers'
+import Logo from '~/components/Logo'
 import Chat from '~/components/Chat'
 import SocialSidebar from '~/components/SocialSidebar'
 
 export default {
   components: {
+    Logo,
     Chat,
     SocialSidebar
   },

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -1,0 +1,201 @@
+<template>
+  <div>
+    <section class="sml-pad-y2 med-pad-y4">
+      <div class="wrapper">
+        <div class="row">
+          <div class="sml-c12 lrg-c8 grid-center article">
+            <Logo/>
+
+            <h1 id="privacy">Privacy Policy</h1>
+            <p>
+              Fight for the Future and Fight for the Future Education Fund (collectively, the “HelloVote Providers”) own and operate the HelloVote website and voter registration tool (collectively, the “HelloVote Tool”). This Privacy Policy governs the manner in which the HelloVote Providers collect, use, maintain and disclose information collected from users (“You” or “Users”) of the HelloVote Tool.
+            </p>
+
+            <h2>The Types of Information the HelloVote Providers Collect</h2>
+            <h3>Non-personally identifiable information</h3>
+            <p>
+              The HelloVote Providers collect non-personally identifiable information about you when you visit the HelloVote Tool. Such information may include the Internet Protocol (IP) address of the computer you used, the type of browser and operating system you used, the date and time you visited the Tool, the Internet address of the site from which you linked to the HelloVote Tool, and which pages you viewed on the Tool.
+            </p>
+
+            <h3>Personally identifiable information</h3>
+            <p>
+              The HelloVote Providers collect personally identifiable information, such as names, cell phone numbers, mailing addresses, dates of birth, party affiliation, social security numbers, state identification numbers, etc., from Users when they voluntarily provide such information to the HelloVote Providers in connection with using the HelloVote Tool.
+            </p>
+
+            <h2>How the HelloVote Providers Use the Information that They Collect</h2>
+            <p>
+              The HelloVote Providers use Users’ personal information to help Users register to vote. The HelloVote Providers will also add you to their distribution lists and may contact you via mail, email and/or text message with information relating to your voter registration, the 2016 general election, as well as other information that the HelloVote Providers think will be of interest to you. If at any time you wish to stop receiving communications from the HelloVote Providers, please follow the unsubscribe instructions included on all such communications from the HelloVote Providers. By providing your cell phone number to the HelloVote Providers, you consent to be contacted at that number on any subject from the HelloVote Providers, unless and until you request that such messages stop. Message and data rates may apply.
+            </p>
+
+            <h2>How the HelloVote Providers Protect User Information</h2>
+            The HelloVote Providers adopt appropriate data collection, storage and processing practices and security measures to help protect against unauthorized access, alteration, disclosure or destruction of your personal information, but the HelloVote Providers cannot guarantee that your information is 100% secure.
+
+            <h2>Sharing Personal Information</h2>
+            <p>
+              The HelloVote Providers use third party service providers to help them operate the HelloVote Tool. These third party service providers have access to Users’ personally identifiable information, but must keep the information confidential and may use it only for purposes relating to the HelloVote Tool, and for no unrelated purpose. Data you send to HelloVote will be visible to your phone company (if you use SMS) or Facebook (if you use Facebook Messenger) and is protected according to their privacy policies and applicable law.
+            </p>
+            <p>
+              In addition, the HelloVote Providers will share a User’s name, mailing address, email address, date of birth, cell phone and political party preference (if required by a particular state and therefore provided by a User) with the organization that the User identifies as his or her source of referral to the HelloVote Tool (“Referring Organization”), if applicable. By identifying a Referring Organization to the HelloVote Providers, you consent to be contacted at that number on any subject from the Referring Organization, unless and until you request that such messages stop. The Referring Organization’s use of your personal information is otherwise governed by the privacy policy of such organization. If a User does not identify a third party organization as the source of referral, the HelloVote Providers will not share that User’s personal information with any third party, other than as set forth herein.
+            </p>
+            <p>
+              Notwithstanding the foregoing, the HelloVote Providers will share personally identifiable information about Users when required to do so by law, or in the good faith belief that such action is necessary to comply with state and federal laws or to respond to a court order, subpoena, or search warrant.
+            </p>
+            <p>
+              Moreover, the HelloVote Providers may share generic aggregated demographic information not linked to any personally identifiable information regarding Users with third parties.
+            </p>
+
+            <h2>Third Party Websites</h2>
+            <p>
+              The HelloVote Providers may provide links from the HelloVote Tool to other websites. The HelloVote Providers do not control the content or links that appear on these third party websites and is not responsible for the practices employed by websites linked to or from the HelloVote Tool. These websites and services have their own privacy policies. Browsing and interaction on any other website, including websites that have a link to or from the HelloVote Tool, is subject to that website’s own terms and policies. This Privacy Policy covers only information collected through the use of the HelloVote Tool. In addition, the HelloVote Providers do not currently respond to web browser “do not track” signals.
+            </p>
+
+            <h2>Compliance with Children’s Online Privacy Protection Act</h2>
+            <p>
+              Protecting the privacy of the young is especially important. For that reason, the HelloVote Providers never collect information through the HelloVote Tool from individuals who the HelloVote Providers know are under 13, and no part of the HelloVote Tool is structured to attract anyone under 13. If the HelloVote Providers become aware of having information about anyone under 13, the HelloVote Providers will promptly delete the information.
+            </p>
+
+            <h2>California Privacy Rights</h2>
+            <p>
+              If you reside in California and have provided your personally identifiable information to the HelloVote Providers, you may request information once per calendar year about the HelloVote Providers’ disclosures of certain categories of your personally identifiable information to third parties for their direct marketing purposes. Such requests must be submitted to the HelloVote Providers at <a href="mailto:team@hello.vote">team@hello.vote</a>.
+            </p>
+
+            <h2>Changes to this Privacy Policy</h2>
+            <p>
+              The HelloVote Providers may update this Privacy Policy at any time. When it does, the HelloVote Providers will revise the updated date at the bottom of this page. The HelloVote Providers encourage Users to frequently check this page for any changes to stay informed about what information the HelloVote Providers collect and how they use that information. You acknowledge and agree that it is you responsibility to review this Privacy Policy periodically and become aware of any modifications since your last visit.
+            <p>
+
+            <h2>Your Acceptance of These Terms</h2>
+            <p>
+              By using this the HelloVote Tool, you signify your acceptance of this Privacy Policy. If you do not agree to this policy, please do not use the HelloVote Tool. Your continued use of the HelloVote Tool following the posting of changes to this Privacy Policy will be deemed your acceptance of those changes.
+            </p>
+
+            <h2>Contacting the HelloVote Providers</h2>
+            <p>
+              If you have any questions about this Privacy Policy or anything relating to the HelloVote Tool, please contact the HelloVote Providers at <a href="mailto:team@hello.vote">team@hello.vote</a>. You may also call toll-free 844-344-3556. To stop receiving text messages from the HelloVote Providers, text “STOP”.
+            </p>
+
+            <p>September 23, 2016</p>
+
+
+            <h1 id="terms">Terms and Conditions of Use</h1>
+            <h2>Your Acceptance of Our Policies</h2>
+            <p>
+              Thank you for visiting the HelloVote website and voter registration tool (collectively, the “HelloVote Tool”), a project of Fight for the Future and Fight for the Future Education Fund (collectively, the “HelloVote Providers”). By using and/or visiting the HelloVote Tool, you agree to these Terms and Conditions of Use, as well as the <a @click.prevent="scrollTo('#privacy')">HelloVote Privacy Policy</a>. You understand that the HelloVote Providers have the right to update these policies from time to time upon posting revised policies on the HelloVote Tool. By continuing to use the HelloVote Tool, you agree to the policies as amended. If you do not agree to any of these terms, please do not use the HelloVote Tool.
+            </p>
+
+            <h2>Links to Third Party Websites</h2>
+            <p>
+              The HelloVote Tool may include links to third party websites. The HelloVote Providers have no control over, and assume no responsibility for, the content, privacy policies, or practices of any third party website. In addition, the HelloVote Providers will not and cannot censor or edit the content of any third party website. By using the HelloVote Tool, you expressly relieve the HelloVote Providres from any and all liability arising from your use of the HelloVote Tool, as well as any third party website.
+            </p>
+
+            <h2>HelloVote Tool Access</h2>
+            <p>
+              The HelloVote Providers hereby grant you permission to use the HelloVote Tool as set forth in these Terms and Conditions of Use, provided that you use the HelloVote Tool solely for noncommercial use. The HelloVote Providers hereby grant you permission to make copies of any part of the HelloVote Tool in any medium to use for noncommercial purposes, provided that you retain the HelloVote Providers’ marks and copyright notices on your copy. You must obtain the HelloVote Providers’ prior consent to use any of the content on the HelloVote Tool for any other purposes. In addition, your use of the HelloVote Tool is conditioned upon your complete compliance with these Terms and Conditions of Use.
+            </p>
+
+            <h2>Restrictions on Use</h2>
+            <p>
+              You agree not to use or launch any automated system, including without limitation, “robots,” “spiders,” “offline readers,” etc., that accesses the HelloVote Tool in a manner that sends more request messages to the HelloVote Providers’ servers in a given period of time than a human can reasonably produce in the same period by using a conventional on-line web browser. Notwithstanding the foregoing, the HelloVote Providers grant the operators of public search engines permission to use spiders to copy materials from the HelloVote Tool for the sole purpose of creating publicly available searchable indices of the materials. The HelloVote Providers reserve the right to revoke these exceptions either generally or in specific cases. You agree not to collect or harvest any personally identifiable information from the HelloVote Tool, nor to use the communication systems provided by the HelloVote Tool for any commercial solicitation purposes. You agree not to solicit any users of the HelloVote Tool for any commercial purposes.
+            </p>
+
+            <h2>Intellectual Property Rights</h2>
+            <p>
+              The content on the HelloVote Tool, including, without limitation, the text, software, scripts, graphics, photos, sounds, music, videos, interactive features and the like (“Content”) and the trademarks, service marks and logos contained therein (“Marks”), are owned by or licensed to the HelloVote Providers, subject to copyright and other intellectual property rights under United States and foreign laws and international conventions. Content on the HelloVote Tool is provided to you AS IS for your information and noncommercial use only and may not be used, copied, reproduced, distributed, transmitted, broadcast, displayed, sold, licensed, or otherwise exploited for any other purposes whatsoever other than as authorized herein without the prior written consent of the respective owners. The HelloVote Providers reserve all rights not expressly granted in and to the HelloVote Tool and the Content. You agree not to engage in the use, copying, or distribution of any of the Content other than as expressly permitted herein. If you download or print a copy of the Content for noncommercial use, you must retain all copyright and other proprietary notices contained therein. You acknowledge that you do not acquire any ownership rights by downloading or printing copyrighted Content. You agree not to circumvent, disable or otherwise interfere with security related features of the HelloVote Tool or features that prevent or restrict use or copying of any Content or enforce limitations on use of the HelloVote Tool or the Content therein.
+            </p>
+
+            <h2>User Submissions</h2>
+            <p>
+              If you submit information to the HelloVote Providers through the HelloVote Tool, you hereby grant the HelloVote Providers a license to use the information as set forth in the <a @click.prevent="scrollTo('#privacy')">HelloVote Privacy Policy</a>.
+            </p>
+
+            <h2>Warranty Disclaimer</h2>
+            <p>
+              YOU AGREE THAT YOUR USE OF THE HELLOVOTE TOOL SHALL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, THE HELLOVOTE PROVIDERS, THEIR OFFICERS, DIRECTORS, EMPLOYEES, AND AGENTS DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE HELLOVOTE TOOL AND YOUR USE THEREOF. THE HELLOVOTE PROVIDERS MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE HELLOVOTE TOOL’S CONTENT OR THE CONTENT OF ANY SITES LINKED TO OR FROM THE HELLOVOTE TOOL AND ASSUMES NO LIABILITY OR RESPONSIBILITY FOR ANY (I) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT, (II) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE HELLOVOTE TOOL, (III) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (IV) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE HELLOVOTE TOOL, (IV) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE THAT MAY BE TRANSMITTED TO OR THROUGH THE HELLOVOTE TOOL BY ANY THIRD PARTY, AND/OR (V) ANY ERRORS OR OMISSIONS IN ANY CONTENT OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TEXTED, EMAILED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE HELLOVOTE TOOL. THE HELLOVOTE PROVIDERS DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE HELLOVOTE TOOL OR ANY HYPERLINKED WEBSITE OR FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND THE HELLOVOTE PROVIDERS WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES.
+            </p>
+
+            <h2>Limitation of Liability</h2>
+            <p>
+              IN NO EVENT SHALL THE HELLOVOTE PROVIDERS, THEIR OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS, BE LIABLE TO YOU FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, PUNITIVE, OR CONSEQUENTIAL DAMAGES WHATSOEVER RESULTING FROM ANY (I) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT, (II) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE HELLOVOTE TOOL, (III) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (IV) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE HELLOVOTE TOOL, (IV) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE, THAT MAY BE TRANSMITTED TO OR THROUGH THE HELLOVOTE TOOL BY ANY THIRD PARTY, AND/OR (V) ANY ERRORS OR OMISSIONS IN ANY CONTENT OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF YOUR USE OF ANY CONTENT POSTED, EMAILED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE HELLOVOTE TOOL, WHETHER BASED ON WARRANTY, CONTRACT, TORT, OR ANY OTHER LEGAL THEORY, AND WHETHER OR NOT THE ORGANIZATIONS ARE ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE FOREGOING LIMITATION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+            </p>
+            <p>
+              YOU SPECIFICALLY ACKNOWLEDGE THAT THE HELLOVOTE PROVIDERS SHALL NOT BE LIABLE FOR USER SUBMISSIONS OR THE DEFAMATORY, OFFENSIVE, OR ILLEGAL CONDUCT OF ANY THIRD PARTY AND THAT THE RISK OF HARM OR DAMAGE FROM THE FOREGOING RESTS ENTIRELY WITH YOU.
+            </p>
+
+            <h2>Indemnity</h2>
+            <p>
+              You agree to defend, indemnify and hold harmless The HelloVote Providers, their officers, directors, employees and agents, from and against any and all claims, damages, obligations, losses, liabilities, costs or debt, and expenses (including but not limited to attorneys’ fees) arising from: (i) your use of and access to the HelloVote Tool; (ii) your violation of any term of these Terms and Conditions of Use; (iii) your violation of any third party right or any law, including without limitation any copyright, property, or privacy right; or (iv) any claim that content you submit via the HelloVote Tool violates any third party right or any law. This defense and indemnification obligation will survive these Terms and Conditions of Use and your use of the HelloVote Tool.
+            </p>
+
+            <h2>Ability to Accept Terms and Conditions of Use</h2>
+            <p>
+              You affirm that you are at least 18 years old and are fully able and competent to enter into the terms, conditions, obligations, affirmations, representations, and warranties set forth in these Terms and Conditions of Use, and to abide by and comply with these Terms and Conditions of Use.
+            </p>
+
+            <h2>Assignment</h2>
+            <p>
+              These Terms and Conditions of Use, and any rights and licenses granted hereunder, may not be transferred or assigned by you, but may be assigned by the HelloVote Providers without restriction.
+            </p>
+
+            <h2>General</h2>
+            <p>
+              These Terms and Conditions of Use shall be governed by the internal substantive laws of the District of Columbia, without respect to its conflict of laws principles. Any claim or dispute between you and The HelloVote Providers that arises in whole or in part from the HelloVote Tool shall be decided exclusively by a court of competent jurisdiction located in the District of Columbia. These Terms and Conditions of Use, together with the Privacy Policy and any other legal notices published by the HelloVote Providers on the HelloVote Tool, shall constitute the entire agreement between you and the HelloVote Providers concerning the HelloVote Tool. If any provision of these Terms and Conditions of Use is deemed invalid by a court of competent jurisdiction, the invalidity of such provision shall not affect the validity of the remaining provisions of these Terms and Conditions of Use, which shall remain in full force and effect. No waiver of any term of this these Terms and Conditions of Use shall be deemed a further or continuing waiver of such term or any other term, and the HelloVote Providers’ failure to assert any right or provision under these Terms and Conditions of Use shall not constitute a waiver of such right or provision. YOU AND THE HELLOVOTE PROVIDERS AGREE THAT ANY CAUSE OF ACTION ARISING OUT OF OR RELATED TO THE HELLOVOTE TOOL MUST COMMENCE WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES. OTHERWISE, SUCH CAUSE OF ACTION IS PERMANENTLY BARRED.
+            </p>
+            <p>
+              Message and data rates may apply.
+            </p>
+
+            <h2>Contacting the HelloVote Providers</h2>
+            <p>
+              If you have any questions about these Terms and Conditions or anything relating to the HelloVote Tool, please contact the HelloVote Providers at <a href="mailto:team@hello.vote">team@hello.vote</a>. You may also call toll-free 844-344-3556. To stop receiving text messages from the HelloVote Providers, text “STOP”.
+            </p>
+
+            <p>
+              September 23, 2016
+            </p>
+          </div> <!-- .c -->
+        </div> <!-- .row -->
+      </div> <!-- .wrapper -->
+    </section>
+
+    <SocialSidebar />
+  </div>
+</template>
+
+<script>
+import config from '~/config'
+import { createMetaTags, smoothScrollToElement } from '~/assets/js/helpers'
+import Logo from '~/components/Logo'
+import SocialSidebar from '~/components/SocialSidebar'
+
+export default {
+  components: {
+    Logo,
+    SocialSidebar
+  },
+
+  head() {
+    return {
+      title: config.sharing.title,
+      meta: createMetaTags({
+        title: config.sharing.title,
+        description: config.sharing.description,
+        image: config.sharing.image,
+        url: config.sharing.url
+      })
+    }
+  },
+
+  methods: {
+    scrollTo(hash) {
+      const duration = 500
+      smoothScrollToElement(hash, duration)
+      // WARNING: Since there is no server a setTimeout is ok. However, with a
+      // server this is a dangerous eval. Remove if this project ever is hosted
+      // with a JS server.
+      setTimeout(() => {
+        location.hash = hash
+      }, duration)
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Located at: `/privacy` with anchor links for `#privacy` and `#terms`. Do we want to continue directing folks to the HelloVote team email?
![screencapture-localhost-3000-privacy-2018-09-11-17_53_14](https://user-images.githubusercontent.com/171493/45389983-98c83600-b5eb-11e8-863d-ee9236ffd886.png)
