### PR TITLE
Firefox workaround for message scroll

### DIFF
--- a/assets/css/components/_chat.scss
+++ b/assets/css/components/_chat.scss
@@ -6,6 +6,10 @@
   flex-direction: column;
   height: $gutter*28;
   overflow-y: auto;
+  padding-bottom: 0;
+}
+.messages > :last-child {
+  padding-bottom: $gutter*2; // NOTE: Workaround for this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=748518
 }
 
 // Chat > Message on the left


### PR DESCRIPTION
Firefox computes the height and padding of scrolled areas differently than some other browsers (this does not occur in Chrome and some other webkit browsers): https://bugzilla.mozilla.org/show_bug.cgi?id=748518 . The solution is not particularly elegant, but ensures no browser has extra padding or no padding.

FF Before fix:
<img width="710" alt="screen shot 2018-09-12 at 1 35 24 pm" src="https://user-images.githubusercontent.com/171493/45442792-ff535f80-b690-11e8-9f3e-7784c2c26c1f.png">

FF After fix:
<img width="669" alt="screen shot 2018-09-12 at 1 35 34 pm" src="https://user-images.githubusercontent.com/171493/45442800-04b0aa00-b691-11e8-9629-2a4e6f87ba40.png">
