### PR TITLE
Update candidate typography

### DIFF
--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -51,6 +51,9 @@ h4 {
     font-size: $font-size-4;
   }
 }
+h5 {
+  line-height: 1.3;
+}
 h6 {
   font-size: $m-font-size-6;
 

--- a/components/Candidates.vue
+++ b/components/Candidates.vue
@@ -17,12 +17,12 @@
             <img :src="candidate.photo" :alt="`${candidate.name} photo`"/>
           </div> <!-- .candidate-photo -->
           <div class="sml-pad-1 is-rounded fill-black candidate-content">
-            <h4 :class="{
+            <h5 :class="{
                     'text-success': candidate.supporter === true,
                     'text-warn': candidate.supporter === false
                  }">
               {{ candidate.name }}
-            </h4>
+            </h5>
             <h6 :class="{ 'text-brand-light': candidate.supporter === null }">
               {{ candidate.party }}
             </h6>


### PR DESCRIPTION
I think these got accidentally larger from my earlier typography update today.

<img width="953" alt="screen shot 2018-09-25 at 6 05 54 pm" src="https://user-images.githubusercontent.com/171493/46046083-bae2ad80-c0ed-11e8-92ea-6986e56ac66b.png">
