### PR TITLE
Workaround for FF bug, store keyRaces in asyncData

### DIFF
--- a/components/Scoreboard.vue
+++ b/components/Scoreboard.vue
@@ -123,9 +123,11 @@
               <div class="text-center">
                 <h2 class="lrg-pad-x4">Help out in these key districts</h2>
                 <p class="sml-push-y2 med-push-y3">
-                 We&rsquo;ve identified <a href="/districts/">{{ keyRaceCount }} extremely close races</a> across the country
-                 where net neutrality supporters can make the most difference pressuring
-                 lawmakers to do the right thing. Click on the links below to help out.
+                  We&rsquo;ve identified
+                  <a href="/districts/">{{ keyRaceCount}} extremely close races</a>
+                  across the country where net neutrality supporters can make
+                  the most difference pressuring lawmakers to do the right
+                  thing. Click on the links below to help out.
                 </p>
 
                 <ActionButtons/>
@@ -161,12 +163,19 @@ export default {
     SocialShareButtons
   },
 
+  props: {
+    keyRaces: {
+      type: Object,
+      default: null,
+      required: true
+    }
+  },
+
   data () {
     return {
       isLoading: false,
       address: null,
       results: null,
-      keyRaces: null,
       errorMessage: null
     }
   },
@@ -184,7 +193,6 @@ export default {
 
   mounted() {
     this.autocompleteAddress()
-    this.fetchKeyRaces()
 
     // uncomment to test target politician
     // this.address = '120 N California St, Yerington, NV'
@@ -252,16 +260,6 @@ export default {
       }
 
       this.isLoading = false
-    },
-
-    async fetchKeyRaces() {
-      try {
-        const { data } = await axios.get('https://data.battleforthenet.com/vfnn/scoreboard/important.json')
-        this.keyRaces = data
-      }
-      catch (error) {
-        console.error(error)
-      }
     },
 
     openModal(type) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -57,7 +57,7 @@
       </div> <!-- .wrapper -->
     </section>
 
-    <Scoreboard/>
+    <Scoreboard :key-races="keyRaces" />
 
     <section id="join" class="sml-pad-y2 med-pad-y4">
       <div class="wrapper">
@@ -230,6 +230,22 @@ export default {
         image: config.sharing.image,
         url: config.sharing.url
       })
+    }
+  },
+
+  async asyncData() {
+    let races = {}
+
+    try {
+      const { data } = await axios.get('https://data.battleforthenet.com/vfnn/scoreboard/important.json')
+      races = data
+    }
+    catch (error) {
+      //
+    }
+
+    return {
+      keyRaces: races
     }
   },
 


### PR DESCRIPTION
When trying to visit `/#join` in Firefox, `keyRaces` loads a moment later and pushes the join section down the page. This is a browser bug... or lack of the scroll anchoring feature that webkit browsers have had for the last 2 years: https://bugzilla.mozilla.org/show_bug.cgi?id=1305957 . Requesting `keyRaces` in `asyncData` means the data is available on page load. I've confirmed with the campaigners that these are unlikely to change often.